### PR TITLE
26 long or looped protocols stop running

### DIFF
--- a/backend/backend/smoothie_pyserial.py
+++ b/backend/backend/smoothie_pyserial.py
@@ -645,7 +645,7 @@ class Smoothie(object):
         result = []
         for port in ports:
             try:
-                if 'tty.usbmodem' in port or 'COM' in port:
+                if 'usbmodem' in port or 'COM' in port:
                     s = serial.Serial(port)
                     s.close()
                     result.append(port)

--- a/backend/backend/smoothie_pyserial.py
+++ b/backend/backend/smoothie_pyserial.py
@@ -259,6 +259,8 @@ class Smoothie(object):
                 string = (string+'\r\n').encode('UTF-8')
                 try:
                     self.serial_port.write(string)
+                    self.theState['stat'] = 1
+                    self.already_trying = False #spaghetti
                 except serial.SerialException:
                     self.callbacker.connection_lost()
             else:


### PR DESCRIPTION
These commit's make two changes to the smoothie module:
1. `self.theState['stat']` is set to `1` manually after any G-Code commands is send to `pyserial.write()`. This is to avoid a firmware bug, where after receiving a G-Code command the smoothieboard will at times **not** respond with `"stat":1`, causing the protocol to freeze.
2. Removing `tty` filter on serial ports, to allow `cu` ports to be listed
