### PR TITLE
31 investigate file path length on windows npm version asar

### DIFF
--- a/main.js
+++ b/main.js
@@ -49,36 +49,43 @@ function startWampRouter() {
     });
 }
 
-function startBackend() {
-  const userDataPath = app.getAppPath('userData')
-
-  if (process.platform == "darwin") {
-    child_process.exec('pkill -9 \"otone_client\"', function(){
-      var backend_path = app.getAppPath() + "/backend-dist/mac/otone_client";
-        backendProcess = child_process.execFile(backend_path, [userDataPath], {stdio: 'ignore' }, function(error, stdout, stderr){
-            console.log(stdout);
-            console.log(stderr);
-            if (error) {
-                throw error;
-            }
-        });
+/**
+ * Starts an executable in a separate process
+ * @param {param} filePath - path to an executable
+ * @param {Array} extraArgs - Array of arguments to pass during invocation of file
+ */
+function execFile(filePath, extraArgs) {
+    backendProcess = child_process.execFile(filePath, extraArgs, {stdio: 'ignore' }, function(error, stdout, stderr){
+        console.log(stdout);
+        console.log(stderr);
+        if (error) {
+            throw error;
+        }
     });
-  }
-  else if (process.platform == "win32") {
-    child_process.exec('taskkill /T /F /IM otone_client.exe', function(){
-      var backend_path = app.getAppPath() + "\\backend-dist\\win\\otone_client.exe";
-        backendProcess = child_process.execFile(backend_path, [userDataPath], {stdio: 'ignore' }, function(error, stdout, stderr){
-            console.log(stdout);
-            console.log(stderr);
-            if (error) {
-                throw error;
-            }
-        });
-  });
 }
-  else{
-    console.log('\n\n\n\nunknown OS: '+process.platform+'\n\n\n\n')
-  }
+
+/**
+ * Starts otone_client backend executable; kills existing process if any
+ */
+function startBackend() {
+    const userDataPath = app.getPath('userData');
+
+    if (process.platform == "darwin") {
+        child_process.exec('pkill -9 \"otone_client\"', function(){
+            var backend_path = app.getAppPath() + "/backend-dist/mac/otone_client";
+            execFile(backend_path, [userDataPath]);
+        });
+    }
+
+    else if (process.platform == "win32") {
+        child_process.exec('taskkill /T /F /IM otone_client.exe', function(){
+            var backend_path = app.getAppPath() + "\\backend-dist\\win\\otone_client.exe";
+            execFile(backend_path, [userDataPath]);
+        });
+    }
+    else{
+        console.log('\n\n\n\nunknown OS: '+process.platform+'\n\n\n\n');
+    }
 }
 
 app.on('ready', createWindow)

--- a/main.js
+++ b/main.js
@@ -11,6 +11,7 @@ const app = electron.app
 const BrowserWindow = electron.BrowserWindow
 
 let backendProcess = undefined
+const userDataPath = app.getAppPath('userData')
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -52,16 +53,22 @@ function startWampRouter() {
 function startBackend() {
   if (process.platform == "darwin") {
     child_process.exec('pkill -9 \"otone_client\"', function(error, stdout, stderr){
+
+      console.log('*&&*&&&&&&&&&&&&&&&&&&&&&&&', app.getAppPath(), app.getPath('userData'))
       var backend_path = app.getAppPath() + "/backend-dist/mac/otone_client";
-      var backend_arg = app.getAppPath();
-      backendProcess = child_process.spawn(backend_path, [backend_arg], {stdio: 'ignore' });
+        backendProcess = child_process.execFile(backend_path, [userDataPath], {stdio: 'ignore' }, function(error, stdout, stderr){
+            console.log(stdout);
+            console.log(stderr);
+            if (error) {
+                throw error;
+            }
+        });
     });
   }
   else if (process.platform == "win32") {
     child_process.exec('taskkill /T /F /IM otone_client.exe',function(error, stdout, stderr){
       var backend_path = app.getAppPath() + "\\backend-dist\\win\\otone_client.exe";
-      var backend_arg = app.getAppPath();
-      backendProcess = child_process.spawn(backend_path, [backend_arg], {stdio: 'ignore' });
+      backendProcess = child_process.spawn(backend_path, [userDataPath], {stdio: 'ignore' });
     });
   }
   else{

--- a/main.js
+++ b/main.js
@@ -11,7 +11,6 @@ const app = electron.app
 const BrowserWindow = electron.BrowserWindow
 
 let backendProcess = undefined
-const userDataPath = app.getAppPath('userData')
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -51,10 +50,10 @@ function startWampRouter() {
 }
 
 function startBackend() {
-  if (process.platform == "darwin") {
-    child_process.exec('pkill -9 \"otone_client\"', function(error, stdout, stderr){
+  const userDataPath = app.getAppPath('userData')
 
-      console.log('*&&*&&&&&&&&&&&&&&&&&&&&&&&', app.getAppPath(), app.getPath('userData'))
+  if (process.platform == "darwin") {
+    child_process.exec('pkill -9 \"otone_client\"', function(){
       var backend_path = app.getAppPath() + "/backend-dist/mac/otone_client";
         backendProcess = child_process.execFile(backend_path, [userDataPath], {stdio: 'ignore' }, function(error, stdout, stderr){
             console.log(stdout);
@@ -66,11 +65,17 @@ function startBackend() {
     });
   }
   else if (process.platform == "win32") {
-    child_process.exec('taskkill /T /F /IM otone_client.exe',function(error, stdout, stderr){
+    child_process.exec('taskkill /T /F /IM otone_client.exe', function(){
       var backend_path = app.getAppPath() + "\\backend-dist\\win\\otone_client.exe";
-      backendProcess = child_process.spawn(backend_path, [userDataPath], {stdio: 'ignore' });
-    });
-  }
+        backendProcess = child_process.execFile(backend_path, [userDataPath], {stdio: 'ignore' }, function(error, stdout, stderr){
+            console.log(stdout);
+            console.log(stderr);
+            if (error) {
+                throw error;
+            }
+        });
+  });
+}
   else{
     console.log('\n\n\n\nunknown OS: '+process.platform+'\n\n\n\n')
   }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,17 @@
   "scripts": {
     "clean": "rm -rf ./out && rm -rf ./releases/*",
     "build:backend:osx": "python3.4 scripts/build_pyinstaller.py",
+    "build:backend:win": "python scripts/build_pyinstaller.py",
+
     "build:frontend:osx": "python3.4 scripts/build_electron_app.py",
+    "build:frontend:win": "python scripts/build_electron_app.py",
+
     "package:osx": "python3.4 scripts/zip_ot_app.py",
-    "release": "npm run build:backend:osx && npm run build:frontend:osx && npm run package:osx",
+    "package:win": "python scripts/zip_ot_app.py",
+
+    "release:osx": "npm run build:backend:osx && npm run build:frontend:osx && npm run package:osx",
+    "release:win": "npm run build:backend:win && npm run build:frontend:win && npm run package:win",
+
     "start": "electron ."
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,17 +5,10 @@
   "main": "main.js",
   "scripts": {
     "clean": "rm -rf ./out && rm -rf ./releases/*",
-    "build:backend:osx": "python3.4 scripts/build_pyinstaller.py",
-    "build:backend:win": "python scripts/build_pyinstaller.py",
-
-    "build:frontend:osx": "python3.4 scripts/build_electron_app.py",
-    "build:frontend:win": "python scripts/build_electron_app.py",
-
-    "package:osx": "python3.4 scripts/zip_ot_app.py",
-    "package:win": "python scripts/zip_ot_app.py",
-
-    "release:osx": "npm run build:backend:osx && npm run build:frontend:osx && npm run package:osx",
-    "release:win": "npm run build:backend:win && npm run build:frontend:win && npm run package:win",
+    "build:backend": "python3.4 scripts/build_pyinstaller.py",
+    "build:frontend": "python3.4 scripts/build_electron_app.py",
+    "package": "python3.4 scripts/zip_ot_app.py",
+    "release": "npm run build:backend && npm run build:frontend && npm run package",
 
     "start": "electron ."
   },

--- a/scripts/build_electron_app.py
+++ b/scripts/build_electron_app.py
@@ -36,17 +36,16 @@ def get_icon_path():
 
 def get_ignore_regex():
     ignore_list = [
-        "node_modules/electron-prebuilt",
-        "node_modules/electron-builder",
+        os.path.join("node_modules", "electron-builder"),
+        os.path.join("node_modules", "electron-prebuilt"),
         "backend$",
         "scripts",
         "tests",
         "docs",
         ".node-version",
         ".python-version",
-        ".git",
         ".idea",
-        ".*.md$",
+        "\.md$",
         "releases",
         "test",
         "requirements.txt",

--- a/scripts/build_electron_app.py
+++ b/scripts/build_electron_app.py
@@ -39,6 +39,7 @@ def get_ignore_regex():
         os.path.join("node_modules", "electron-builder"),
         os.path.join("node_modules", "electron-prebuilt"),
         "backend$",
+        "backend-env",
         "scripts",
         "tests",
         "docs",

--- a/scripts/build_electron_app.py
+++ b/scripts/build_electron_app.py
@@ -80,8 +80,8 @@ def build_electron_app():
         "--out", output_dir,
         "--icon", get_icon_path(),
         "--asar", "true",
-        "--overwrite", "true",
-        "--prune", "true",
+        "--overwrite",
+        "--prune",
     ] + get_ignore_regex()
 
 

--- a/scripts/build_electron_app.py
+++ b/scripts/build_electron_app.py
@@ -46,6 +46,7 @@ def build_electron_app():
         "--out", "out",
         "--icon", os.path.join(project_root_dir, "build-assets", "icon.ico"),
         "--ignore", get_ignore_regex(),
+        "--asar", "true",
         "--overwrite",
         "--prune",
     ]

--- a/scripts/build_electron_app.py
+++ b/scripts/build_electron_app.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 
 
@@ -38,7 +39,7 @@ def build_electron_app():
     print(script_tag + "Running electron-packager process.")
 
     process_args = [
-        "electron-packager",
+        shutil.which("electron-packager"),
         project_root_dir,
         "OpenTrons",
         "--platform", "darwin",

--- a/scripts/build_pyinstaller.py
+++ b/scripts/build_pyinstaller.py
@@ -49,8 +49,8 @@ def get_os():
 
     os_found = platform.system()
     if os_found == "Windows":
-        raise SystemExit(script_tab + "OS found is: %s\n" % valid_os[0] +
-                         "Exit: This script is not design to run on Windows.")
+        print(script_tab + "OS found is: %s" % valid_os[0])
+        return valid_os[0]
     elif os_found == "Linux":
         print(script_tab + "OS found is: %s" % valid_os[1])
         return valid_os[1]

--- a/scripts/build_pyinstaller.py
+++ b/scripts/build_pyinstaller.py
@@ -5,7 +5,6 @@ import platform
 import subprocess
 
 
-spec_coll_name = "otone_client"
 exec_folder_name = "backend-dist"
 script_tag = "[OT-App Backend build] "
 script_tab = "                    "
@@ -33,7 +32,7 @@ def get_os():
     Gets the OS to based on the command line argument of the platform info.
     Only possibilities are: "windows", "mac", "linux"
     """
-    valid_os = ["windows", "linux", "mac"]
+    valid_os = ["win", "linux", "mac"]
 
     print(script_tab + "Checking for command line argument indicated OS:")
     if len(sys.argv) > 1:
@@ -61,6 +60,17 @@ def get_os():
     else:
         raise SystemExit("Exit: OS data found is invalid '%s'" % os_found)
 
+def get_spec_coll_name():
+    os_type = get_os()
+    if os_type == 'win':
+        return "otone_client.exe"
+    elif os_type == 'mac':
+        return "otone_client"
+    raise SystemExit(
+        'Unable to determine pyinstaller.spec COLL name for OS: {}'.format(
+            os_type
+        )
+    )
 
 def remove_pyinstaller_temps():
     """
@@ -98,7 +108,7 @@ def move_executable_folder(final_exec_dir):
     Moves the PyInstaller executable folder from dist to project root.
     :return: Boolean indicating the success state of the operation.
     """
-    original_exec_dir = os.path.join(project_root_dir, "dist", spec_coll_name)
+    original_exec_dir = os.path.join(project_root_dir, "dist", get_spec_coll_name())
     if os.path.exists(original_exec_dir):
         print(script_tab + "Moving exec files from %s \n" % original_exec_dir +
               script_tab + "to %s" % final_exec_dir)
@@ -132,7 +142,9 @@ def build_ot_python_backend_executable():
                                       "PyInstaller execution.")
 
     print(script_tag + "Removing old OT-App Backend executable directory.")
-    backend_exec_path = os.path.join(exec_folder_name, get_os(), spec_coll_name)
+    backend_exec_path = os.path.join(
+        exec_folder_name, get_os(), get_spec_coll_name()
+    )
     if os.path.isfile(backend_exec_path):
         os.remove(backend_exec_path)
 


### PR DESCRIPTION
This PR accomplishes several things,
- Packages app using asar format for application files which gives the following benefits,
  - No more path name too long on windows since app dependencies are packaged into the asar which is a tar like file
  - Easier to copy/delete app since there aren't a bajillion files to move

The backend executable is also included in the asar format and is unpacked when invoked via `child_process.execFile`. Electron node modules can read from an asar format without unpacking it but certain calls require unarchiving files from the asar file.

> With special patches in Electron, Node APIs like fs.readFile and require treat asar archives as virtual directories, and the files in it as normal files in the filesystem.

More info: http://electron.atom.io/docs/tutorial/application-packaging/#using-asar-archives

And here: http://electron.atom.io/docs/tutorial/application-packaging/#extra-unpacking-on-some-apis
- Make backend write otone_data folder to an OS specific location that is retrieved using `app.getPath('userData')`.
  - On windows data is written to, `%APPDATA%/ot-one-desktop-app`
  - On mac data is written to `~/Library/Application Support/ot-one-desktop-app`

This allows the app to write data outside of the app install folder. This will enable us to update the app without worrying about losing user data

Source: https://github.com/electron/electron/blob/master/docs/api/app.md#appgetpathname

Also modified `scripts/build_electron_app.py` and `scripts/build_pyinstaller.py` to run on windows as a temp measure until windows build process is ready.
