### PR TITLE
20160801 120000 lock node version on travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   # Install Python 2 and 3 with pip and check versions
   - brew tap drolando/homebrew-deadsnakes
   - brew install python34
-  # - PATH=/usr/local/bin:$PATH
+  - PATH=$PATH:/usr/local/bin
   - echo $PATH
   - brew link --overwrite python34
   - python3.4 --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
   - mkdir ~/.nvm && export NVM_DIR=~/.nvm && source $(brew --prefix nvm)/nvm.sh && nvm alias default 6.0.0
   - echo "$(brew --prefix nvm)/nvm.sh" >> ~/.bashrc
   - nvm install 6.0.0
+  - nvm use 6.0.0
   - node --version
   - npm --version
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # We are using the iOS build system to create Mac OS X python builds
-language: objective-c
+osx_image: beta-xcode6.1
+language: node_js
 node_js:
   - "6.0.0"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   # - nodenv version
   # - nodenv rehash
   - brew install nvm
-  - mkdir ~/.nvm && export NVM_DIR=~/.nvm && source $(brew --prefix nvm)/nvm.sh
+  - mkdir ~/.nvm && export NVM_DIR=~/.nvm && source $(brew --prefix nvm)/nvm.sh && nvm alias default 6.0.0
   - nvm install 6.0.0
   - node --version
   - npm --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,15 @@ before_install:
   - python --version
   - python -c "import struct; print(struct.calcsize('P') * 8)"
 
+  # Install node.js
+  - brew install nodenv
+  - brew unlink node
+  - nodenv install 6.0.0
+  - nodenv versions
+  - nodenv local v6.0.0
+  - nodenv version
+  - npm --version
+
   # Install Python 2 and 3 with pip and check versions
   - brew update
   - brew tap drolando/homebrew-deadsnakes
@@ -23,15 +32,6 @@ before_install:
 
   - pip3.4 install -r requirements.txt
 
-  # Install node.js
-  - brew install nodenv
-  - brew unlink node
-  - nodenv install 6.0.0
-  - nodenv local 6.0.0
-  - node --version
-  - npm --version
-
-# Build and pack Ardublockly
 install:
   - python3.4 scripts/build_pyinstaller.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
   # - nodenv rehash
   - brew install nvm
   - mkdir ~/.nvm && export NVM_DIR=~/.nvm && source $(brew --prefix nvm)/nvm.sh && nvm alias default 6.0.0
+  - echo "$(brew --prefix nvm)/nvm.sh" >> ~/.bashrc
   - nvm install 6.0.0
   - node --version
   - npm --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,22 +28,20 @@ before_install:
   - npm install
 
   # Install Python 2 and 3 with pip and check versions
-#  - brew tap drolando/homebrew-deadsnakes
-#  - brew install python34
-#  - PATH=/usr/local/bin:$PATH
-#  - echo $PATH
-#  - brew link --overwrite python34
-#  - python3.4 --version
-#  - python3.4 -c "import struct; print(struct.calcsize('P') * 8)"
+  - brew tap drolando/homebrew-deadsnakes
+  - brew install python34
+  - PATH=/usr/local/bin:$PATH
+  - echo $PATH
+  - brew link --overwrite python34
+  - python3.4 --version
+  - python3.4 -c "import struct; print(struct.calcsize('P') * 8)"
 
   # Install Python packages (built with Python 3)
-#  - pip3.4 install pyinstaller
-#  - pyinstaller --version
-#  - pip3.4 install -r requirements.txt
+  - pip3.4 install pyinstaller
+  - pyinstaller --version
+  - pip3.4 install -r requirements.txt
 
 install:
-  # - python3.4 scripts/build_pyinstaller.py
-
   - npm --version
   - which npm
   - npm install electron-packager

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,9 @@ before_install:
   - pip3.4 install -r requirements.txt
 
   # Install node.js
+  - brew install nodenv
   - brew unlink node
-  - brew install node
+  - nodenv install 6.0.0
   - node --version
   - npm --version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ before_install:
   - nodenv versions
   - nodenv local 6.0.0
   - nodenv version
+  - nodenv rehash
   - npm --version
+  - nodenv which npm
 
   # Install Python 2 and 3 with pip and check versions
   - brew tap drolando/homebrew-deadsnakes

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,6 @@ before_install:
   - brew update
 
   # Install node.js
-  # - brew install nodenv
-  # - brew unlink node
-  # - nodenv install 6.0.0
-  # - nodenv versions
-  # - nodenv local 6.0.0
-  # - nodenv version
-  # - nodenv rehash
   - brew install nvm
   - mkdir ~/.nvm && export NVM_DIR=~/.nvm && source $(brew --prefix nvm)/nvm.sh && nvm alias default 6.0.0
   - echo "$(brew --prefix nvm)/nvm.sh" >> ~/.bashrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 # We are using the iOS build system to create Mac OS X python builds
-osx_image: beta-xcode6.1
-language: node_js
-node_js:
-  - "6.0.0"
+language: objective-c
 
 before_install:
   # OS extra info
@@ -21,6 +18,7 @@ before_install:
   # - nodenv local 6.0.0
   # - nodenv version
   # - nodenv rehash
+  - nvm install 6.0.0
   - node --version
   - npm --version
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
 install:
   - python3.4 scripts/build_pyinstaller.py
 
-  - npm install -g electron-packager
+  - npm install electron-packager
   - npm install
   - npm run release
   - ls out

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,10 @@ before_install:
   # Install Python 2 and 3 with pip and check versions
   - brew tap drolando/homebrew-deadsnakes
   - brew install python34
-  - PATH=$PATH:/usr/local/bin
-  - echo $PATH
   - brew link --overwrite python34
   - python3.4 --version
   - python3.4 -c "import struct; print(struct.calcsize('P') * 8)"
+  - echo $PATH
 
   # Install Python packages (built with Python 3)
   - pip3.4 install pyinstaller
@@ -42,8 +41,8 @@ before_install:
   - pip3.4 install -r requirements.txt
 
 install:
+  - node --version
   - npm --version
-  - which npm
   - npm install electron-packager
   - npm install
   - npm run release

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
   # - nodenv local 6.0.0
   # - nodenv version
   # - nodenv rehash
+  - brew install nvm
   - nvm install 6.0.0
   - node --version
   - npm --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
   # - nodenv version
   # - nodenv rehash
   - brew install nvm
+  - mkdir ~/.nvm && export NVM_DIR=~/.nvm && source $(brew --prefix nvm)/nvm.sh
   - nvm install 6.0.0
   - node --version
   - npm --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   # Install Python 2 and 3 with pip and check versions
   - brew tap drolando/homebrew-deadsnakes
   - brew install python34
-  - PATH=/usr/local/bin:$PATH
+  # - PATH=/usr/local/bin:$PATH
   - echo $PATH
   - brew link --overwrite python34
   - python3.4 --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_install:
   - brew install nodenv
   - brew unlink node
   - nodenv install 6.0.0
+  - nodenv local 6.0.0
   - node --version
   - npm --version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,22 +27,24 @@ before_install:
   - npm install
 
   # Install Python 2 and 3 with pip and check versions
-  - brew tap drolando/homebrew-deadsnakes
-  - brew install python34
-  - PATH=/usr/local/bin:$PATH
-  - echo $PATH
-  - brew link --overwrite python34
-  - python3.4 --version
-  - python3.4 -c "import struct; print(struct.calcsize('P') * 8)"
+#  - brew tap drolando/homebrew-deadsnakes
+#  - brew install python34
+#  - PATH=/usr/local/bin:$PATH
+#  - echo $PATH
+#  - brew link --overwrite python34
+#  - python3.4 --version
+#  - python3.4 -c "import struct; print(struct.calcsize('P') * 8)"
 
   # Install Python packages (built with Python 3)
-  - pip3.4 install pyinstaller
-  - pyinstaller --version
-  - pip3.4 install -r requirements.txt
+#  - pip3.4 install pyinstaller
+#  - pyinstaller --version
+#  - pip3.4 install -r requirements.txt
 
 install:
-  - python3.4 scripts/build_pyinstaller.py
+  # - python3.4 scripts/build_pyinstaller.py
 
+  - npm --version
+  - which npm
   - npm install electron-packager
   - npm install
   - npm run release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 # We are using the iOS build system to create Mac OS X python builds
 language: objective-c
+node_js:
+  - "6.0.0"
 
 before_install:
   # OS extra info
@@ -11,15 +13,16 @@ before_install:
   - brew update
 
   # Install node.js
-  - brew install nodenv
-  - brew unlink node
-  - nodenv install 6.0.0
-  - nodenv versions
-  - nodenv local 6.0.0
-  - nodenv version
-  - nodenv rehash
+  # - brew install nodenv
+  # - brew unlink node
+  # - nodenv install 6.0.0
+  # - nodenv versions
+  # - nodenv local 6.0.0
+  # - nodenv version
+  # - nodenv rehash
+  - node --version
   - npm --version
-  - nodenv which npm
+  - npm install
 
   # Install Python 2 and 3 with pip and check versions
   - brew tap drolando/homebrew-deadsnakes
@@ -30,7 +33,7 @@ before_install:
   - python3.4 --version
   - python3.4 -c "import struct; print(struct.calcsize('P') * 8)"
 
-  # Install Python packages (built with Python 3, tests for 2 and 3)
+  # Install Python packages (built with Python 3)
   - pip3.4 install pyinstaller
   - pyinstaller --version
   - pip3.4 install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ before_install:
   # Install Python packages (built with Python 3, tests for 2 and 3)
   - pip3.4 install pyinstaller
   - pyinstaller --version
-
   - pip3.4 install -r requirements.txt
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - brew unlink node
   - nodenv install 6.0.0
   - nodenv versions
-  - nodenv local v6.0.0
+  - nodenv local 6.0.0
   - nodenv version
   - npm --version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ before_install:
   - python --version
   - python -c "import struct; print(struct.calcsize('P') * 8)"
 
+  # Update brew
+  - brew update
+
   # Install node.js
   - brew install nodenv
   - brew unlink node
@@ -17,7 +20,6 @@ before_install:
   - npm --version
 
   # Install Python 2 and 3 with pip and check versions
-  - brew update
   - brew tap drolando/homebrew-deadsnakes
   - brew install python34
   - PATH=/usr/local/bin:$PATH

--- a/scripts/build_electron_app.py
+++ b/scripts/build_electron_app.py
@@ -51,7 +51,7 @@ def build_electron_app():
         "--prune",
     ]
 
-    electron_packager_process = subprocess.Popen(process_args, env=os.environ.copy())
+    electron_packager_process = subprocess.Popen(process_args)
     electron_packager_process.communicate()
 
     if electron_packager_process.returncode != 0:

--- a/scripts/build_electron_app.py
+++ b/scripts/build_electron_app.py
@@ -50,7 +50,7 @@ def build_electron_app():
         "--prune",
     ]
 
-    electron_packager_process = subprocess.Popen(process_args)
+    electron_packager_process = subprocess.Popen(process_args, env=os.environ.copy())
     electron_packager_process.communicate()
 
     if electron_packager_process.returncode != 0:

--- a/scripts/build_electron_app.py
+++ b/scripts/build_electron_app.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 
 
@@ -38,7 +39,7 @@ def build_electron_app():
     print(script_tag + "Running electron-packager process.")
 
     process_args = [
-        "electron-packager",
+        shutil.which("electron-packager"),
         project_root_dir,
         "OpenTrons",
         "--platform", "darwin",

--- a/scripts/build_pyinstaller.py
+++ b/scripts/build_pyinstaller.py
@@ -8,7 +8,7 @@ import subprocess
 spec_coll_name = "otone_client"
 exec_folder_name = "backend-dist"
 script_tag = "[OT-App Backend build] "
-script_tab = "                    "
+script_tab = "                       "
 
 # The project_root_dir depends on the location of this file, so it cannot be
 # moved without updating this line


### PR DESCRIPTION
This PR sets up nvm on travis-ci and uses it to install nodejs `6.0.0` and npm `3.8.6` to build the electron app.

Previously the latest version of node was being installed but the node versions >= 6.3.x broke the current build due to an incompatibility with websocket.js. We now lock in node to version 6.0.0.
