### PR TITLE
Save volume input

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -128,7 +128,10 @@ app.on('window-all-closed', function () {
       }
     });
 
-    powerSaverBlocker.stop(powerSaver.id)
-    backendProcess.shutdown()
     app.quit()
 })
+
+app.on('quit', function(){
+    powerSaveBlocker.stop(powerSaver.id);
+    backendProcess.shutdown();
+});

--- a/app/main.js
+++ b/app/main.js
@@ -13,7 +13,7 @@ const addMenu = require('./menu').addMenu;
 const winston = require('winston')
 
 let backendProcess = undefined
-let powerSaver_ID = undefined
+let powerSaverID = undefined
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -109,7 +109,7 @@ function startBackend() {
 }
 
 function blockPowerSaver() {
-  powerSaver_ID = powerSaveBlocker.start('prevent-display-sleep')
+  powerSaverID = powerSaveBlocker.start('prevent-display-sleep')
 }
 
 app.on('ready', createWindow)
@@ -132,7 +132,7 @@ app.on('quit', function(){
       }
     });
     backendProcess.shutdown();
-    if (powerSaveBlocker.isStarted(powerSaver_ID)) {
-      powerSaveBlocker.stop(powerSaver_ID);
+    if (powerSaveBlocker.isStarted(powerSaverID)) {
+      powerSaveBlocker.stop(powerSaverID);
     }
 });

--- a/app/main.js
+++ b/app/main.js
@@ -13,7 +13,7 @@ const addMenu = require('./menu').addMenu;
 const winston = require('winston')
 
 let backendProcess = undefined
-let powerSaver = undefined
+let powerSaver_ID = undefined
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -109,7 +109,7 @@ function startBackend() {
 }
 
 function blockPowerSaver() {
-  powerSaver = powerSaveBlocker.start('prevent-display-sleep')
+  powerSaver_ID = powerSaveBlocker.start('prevent-display-sleep')
 }
 
 app.on('ready', createWindow)
@@ -119,6 +119,10 @@ app.on('ready', addMenu)
 app.on('ready', blockPowerSaver)
 
 app.on('window-all-closed', function () {
+    app.quit()
+})
+
+app.on('quit', function(){
     process.once("uncaughtException", function (error) {
       // Ugly but convenient. If we have more than one uncaught exception
       // then re-raise. Otherwise Do nothing as that exception is caused by
@@ -127,11 +131,8 @@ app.on('window-all-closed', function () {
           throw error;
       }
     });
-
-    app.quit()
-})
-
-app.on('quit', function(){
-    powerSaveBlocker.stop(powerSaver.id);
     backendProcess.shutdown();
+    if (powerSaveBlocker.isStarted(powerSaver_ID)) {
+      powerSaveBlocker.stop(powerSaver_ID);
+    }
 });

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -372,7 +372,7 @@
                     <button type="button" class="btn btn-sm tron-black b" onclick="pickupTip('b')">Pickup-Tip</button>
                   </div>
                   <br />
-                  <div style="display:inline-block; margin-top:20px;">
+                  <div style="display:inline-block; margin-top:30px;">
 
                     <div>
                       <span class="shortform pipette-Center">Center</span> (uL): <code id="pipetteVolume_a">null</code>

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -356,37 +356,23 @@
             </div>
             <div class="col-xs-4 col-sm-4 col-md-4 col-lg-4">
               <div class="UI-block center-block large-panel pipette-panel">
-                <legend class="UI-Title">Calibrate Volume</legend>
+                <legend class="UI-Title">Save Pipette Volume</legend>
                 <div style="margin-left:20px;">
-                  <h4 style="padding-top:10px;">
-                    <span>Testing uL: </span>
-                    <select type="text" id="volume_testing">
-                      <option value="1000">1000</option>
-                      <option value="500">500</option>
-                      <option value="200">200</option>
-                      <option value="100">100</option>
-                      <option value="50">50</option>
-                      <option value="25">25</option>
-                      <option value="10">10</option>
-                      <option value="5">5</option>
-                    </select>
-                  </h4>
-                  <br/>
                   <div style="display:inline-block; ">
                     <div>
                       <span class="shortform pipette-Left">Left</span> (uL): <code id="pipetteVolume_b">null</code>
                     </div>
-                    <br/>
-                    <button type="button" class="btn btn-sm tron-black b" onclick="saveVolume('b')">Save
-                    </button>
+                    <div>
+                      <span class="shortform pipette-Left">Save (uL):</span>
+                      <input type="text" id="volume_input_b" style="width:60px">
+                      </input>
+                      <button type="button" class="btn btn-sm tron-black b" onclick="saveVolume('b')">Save
+                      </button>
+                    </div>
                     <button type="button" class="btn btn-sm tron-black b" onclick="moveVolume('b')">Test</button>
-
-
-
-                    <button type="button" class="btn btn-sm tron-black b" onclick="shakePipette('b')">Shake</button>
-
                     <button type="button" class="btn btn-sm tron-black b" onclick="pickupTip('b')">Pickup-Tip</button>
                   </div>
+                  <br />
                   <div style="display:inline-block; margin-top:20px;">
 
                     <div>
@@ -397,13 +383,6 @@
                       Save
                     </button>
                     <button type="button" class="btn btn-sm tron-blue a" onclick="moveVolume('a')">Test</button>
-
-
-
-
-
-                    <button type="button" class="btn btn-sm tron-blue a" onclick="shakePipette('a')">Shake</button>
-
                     <button type="button" class="btn btn-sm tron-blue a" onclick="pickupTip('a')">Pickup-Tip</button>
                   </div>
 

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -366,9 +366,8 @@
                       <span class="shortform pipette-Left">Save (uL):</span>
                       <input type="text" id="volume_input_b" style="width:60px">
                       </input>
-                      <button type="button" class="btn btn-sm tron-black b" onclick="saveVolume('b')">Save
-                      </button>
                     </div>
+                    <button type="button" class="btn btn-sm tron-black b" onclick="saveVolume('b')">Save</button>
                     <button type="button" class="btn btn-sm tron-black b" onclick="moveVolume('b')">Test</button>
                     <button type="button" class="btn btn-sm tron-black b" onclick="pickupTip('b')">Pickup-Tip</button>
                   </div>
@@ -376,12 +375,14 @@
                   <div style="display:inline-block; margin-top:20px;">
 
                     <div>
-                      <span class="shortform pipette-Center">Center</span> (uL): <code id="pipetteVolume_a">null</code>
+                      <span class="shortform pipette-Left">Right</span> (uL): <code id="pipetteVolume_a">null</code>
                     </div>
-                    <br/>
-                    <button type="button" class="btn btn-sm tron-blue a" onclick="saveVolume('a')">
-                      Save
-                    </button>
+                    <div>
+                      <span class="shortform pipette-Left">Save (uL):</span>
+                      <input type="text" id="volume_input_a" style="width:60px">
+                      </input>
+                    </div>
+                    <button type="button" class="btn btn-sm tron-blue a" onclick="saveVolume('a')">Save</button>
                     <button type="button" class="btn btn-sm tron-blue a" onclick="moveVolume('a')">Test</button>
                     <button type="button" class="btn btn-sm tron-blue a" onclick="pickupTip('a')">Pickup-Tip</button>
                   </div>

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -363,7 +363,7 @@
                       <span class="shortform pipette-Left">Left</span> (uL): <code id="pipetteVolume_b">null</code>
                     </div>
                     <div>
-                      <span class="shortform pipette-Left">Save (uL):</span>
+                      <span class="shortform">Save Volume (uL):</span>
                       <input type="text" id="volume_input_b" style="width:60px">
                       </input>
                     </div>
@@ -375,10 +375,10 @@
                   <div style="display:inline-block; margin-top:20px;">
 
                     <div>
-                      <span class="shortform pipette-Left">Right</span> (uL): <code id="pipetteVolume_a">null</code>
+                      <span class="shortform pipette-Center">Center</span> (uL): <code id="pipetteVolume_a">null</code>
                     </div>
                     <div>
-                      <span class="shortform pipette-Left">Save (uL):</span>
+                      <span class="shortform">Save Volume (uL):</span>
                       <input type="text" id="volume_input_a" style="width:60px">
                       </input>
                     </div>

--- a/app/src/js/main.js
+++ b/app/src/js/main.js
@@ -630,6 +630,8 @@ var socketHandler = {
       robotState.pipettes[axis].blowout = data[axis].blowout || robotState.pipettes[axis].blowout;
       robotState.pipettes[axis].droptip = data[axis].droptip || robotState.pipettes[axis].droptip;
       robotState.pipettes[axis].volume = data[axis].volume || robotState.pipettes[axis].volume;
+      
+      document.getElementById('pipetteVolume_'+axis).innerHTML = robotState.pipettes[axis].volume.toFixed(2);
 
       try{
         document.getElementById('pipetteVolume_'+axis).innerHTML = robotState.pipettes[axis].volume.toFixed(2);
@@ -1261,42 +1263,22 @@ function moveVolume (axis) {
 /////////////////////////////////
 /////////////////////////////////
 
-function saveVolume (axis) {
+function saveVolume (axis, volume) {
 
   if(!robot_connected){
     alert('Please first connect to your machine');
     return;
   }
 
-  var volumeMenu = document.getElementById('volume_testing');
-  var volume = volumeMenu ? volumeMenu.value : undefined;
+  if(volume && !isNaN(volume)) {
 
-  if(volume) {
-
-    // find the percentage we've moved between "bottom" and "top"
-    var totalDistance = robotState.pipettes[axis].bottom - robotState.pipettes[axis].top;
-    var distanceFromBottom = robotState.pipettes[axis].bottom - robotState[axis];
-    var percentageFromBottom = distanceFromBottom / totalDistance;
-
-    if(debug===true) console.log('saved at '+percentageFromBottom);
-
-    // determine the number of uL this pipette can do based of percentage
-    var totalVolume = volume / percentageFromBottom;
-
-    if(!isNaN(totalVolume) && totalVolume>0) {
-
-      if(debug===true) console.log('pipetteVolume_'+axis);
-      document.getElementById('pipetteVolume_'+axis).innerHTML = totalVolume.toFixed(2);
-      robotState.pipettes[axis].volume = totalVolume;
-
-      sendMessage({
-        'type':'saveVolume',
-        'data': {
-          'volume':totalVolume,
-          'axis':axis
-        }
-      });
-    }
+    sendMessage({
+      'type':'saveVolume',
+      'data': {
+        'volume':volume,
+        'axis':axis
+      }
+    });
     else  {
       alert('error saving new volume, check the pipette\'s coordinates');
     }

--- a/app/src/js/main.js
+++ b/app/src/js/main.js
@@ -630,8 +630,6 @@ var socketHandler = {
       robotState.pipettes[axis].blowout = data[axis].blowout || robotState.pipettes[axis].blowout;
       robotState.pipettes[axis].droptip = data[axis].droptip || robotState.pipettes[axis].droptip;
       robotState.pipettes[axis].volume = data[axis].volume || robotState.pipettes[axis].volume;
-      
-      document.getElementById('pipetteVolume_'+axis).innerHTML = robotState.pipettes[axis].volume.toFixed(2);
 
       try{
         document.getElementById('pipetteVolume_'+axis).innerHTML = robotState.pipettes[axis].volume.toFixed(2);
@@ -1200,61 +1198,45 @@ function moveVolume (axis) {
     return;
   }
 
-  var volumeMenu = document.getElementById('volume_testing');
-  var volume = volumeMenu ? volumeMenu.value : undefined;
+  if(axis) {
 
-  if(debug===true) console.log('volume '+volume);
-
-  if(volume) {
-
-    volume *= -1; // negative because we're just sucking up right now
-
-    // deduce the percentage the plunger should move to
-    var totalPipetteVolume = robotState.pipettes[axis].volume;
-    if(!totalPipetteVolume) totalPipetteVolume = 200;
-    if(!isNaN(totalPipetteVolume)) {
-      var plungerPercentage = volume / totalPipetteVolume;
-
-      if(debug===true) console.log('moving to '+plungerPercentage);
-
-      sendMessage({
-        'type' : 'movePlunger',
-        'data' : {
-          'axis' : axis,
-          'locations' : [
-            {
-              'z' : -20,
-              'relative' : true
-            },
-            {
-              'speed' : 300
-            },
-            {
-              'plunger' : 'blowout'
-            },
-            {
-              'plunger' : 1
-            },
-            {
-              'z' : 20,
-              'relative' : true
-            },
-            {
-              'plunger' : 1
-            },
-            {
-              'speed' : 300
-            },
-            {
-              'plunger' : 1 + plungerPercentage // say 1+ because we're backing off from 1 right now
-            }
-          ]
-        }
-      });
-    }
-    else {
-      alert('Please calibrate pipette volume first');
-    }
+    sendMessage({
+      'type' : 'movePlunger',
+      'data' : {
+        'axis' : axis,
+        'locations' : [
+          {
+            'z' : -20,
+            'relative' : true
+          },
+          {
+            'speed' : 300
+          },
+          {
+            'plunger' : 'blowout'
+          },
+          {
+            'plunger' : 1
+          },
+          {
+            'z' : 20,
+            'relative' : true
+          },
+          {
+            'plunger' : 1
+          },
+          {
+            'speed' : 300
+          },
+          {
+            'plunger' : 0
+          }
+        ]
+      }
+    });
+  }
+  else {
+    alert('Please calibrate pipette volume first');
   }
 }
 
@@ -1263,26 +1245,37 @@ function moveVolume (axis) {
 /////////////////////////////////
 /////////////////////////////////
 
-function saveVolume (axis, volume) {
+function saveVolume (axis) {
 
-  if(!robot_connected){
-    alert('Please first connect to your machine');
-    return;
-  }
+  // if(!robot_connected){
+  //   alert('Please first connect to your machine');
+  //   return;
+  // }
 
-  if(volume && !isNaN(volume)) {
+  // var volumeInput = document.getElementById('volume_input_'+axis);
+  // var volume = volumeMenu ? volumeMenu.value : undefined;
 
-    sendMessage({
-      'type':'saveVolume',
-      'data': {
-        'volume':volume,
-        'axis':axis
-      }
-    });
-    else  {
-      alert('error saving new volume, check the pipette\'s coordinates');
-    }
-  }
+  // volume = Number(volume);
+
+  // if(!isNaN(volume) && volume>0) {
+
+  //   if(debug===true) console.log('pipetteVolume_'+axis);
+  //   document.getElementById('pipetteVolume_'+axis).innerHTML = volume.toFixed(2);
+  //   robotState.pipettes[axis].volume = volume;
+
+  //   sendMessage({
+  //     'type':'saveVolume',
+  //     'data': {
+  //       'volume':volume,
+  //       'axis':axis
+  //     }
+  //   });
+
+  //   volumeInput.value = '';
+  // }
+  // else  {
+  //   alert('error saving new volume');
+  // }
 }
 
 /////////////////////////////////

--- a/app/src/js/main.js
+++ b/app/src/js/main.js
@@ -1247,35 +1247,31 @@ function moveVolume (axis) {
 
 function saveVolume (axis) {
 
-  // if(!robot_connected){
-  //   alert('Please first connect to your machine');
-  //   return;
-  // }
+  if(!robot_connected){
+    alert('Please first connect to your machine');
+    return;
+  }
 
-  // var volumeInput = document.getElementById('volume_input_'+axis);
-  // var volume = volumeMenu ? volumeMenu.value : undefined;
+  var volumeInput = document.getElementById('volume_input_'+axis);
+  var volume = volumeInput ? volumeInput.value : undefined;
 
-  // volume = Number(volume);
+  volume = Number(volume);
 
-  // if(!isNaN(volume) && volume>0) {
+  if(!isNaN(volume) && volume>0) {
 
-  //   if(debug===true) console.log('pipetteVolume_'+axis);
-  //   document.getElementById('pipetteVolume_'+axis).innerHTML = volume.toFixed(2);
-  //   robotState.pipettes[axis].volume = volume;
+    sendMessage({
+      'type':'saveVolume',
+      'data': {
+        'volume':volume,
+        'axis':axis
+      }
+    });
 
-  //   sendMessage({
-  //     'type':'saveVolume',
-  //     'data': {
-  //       'volume':volume,
-  //       'axis':axis
-  //     }
-  //   });
-
-  //   volumeInput.value = '';
-  // }
-  // else  {
-  //   alert('error saving new volume');
-  // }
+    volumeInput.value = '';
+  }
+  else  {
+    alert('error saving new volume');
+  }
 }
 
 /////////////////////////////////

--- a/backend/backend/head.py
+++ b/backend/backend/head.py
@@ -394,10 +394,13 @@ class Head:
     def save_volume(self, data):
         """Save pipette volume to otone_data/pipette_values.json
         """
-        if(self.PIPETTES[data.axis] and data.volume is not None and data.volume > 0):
-            self.PIPETTES[data.axis].volume = data.volume
+        logger.debug('saved volume: {}'.format(data['volume']))
+        if(self.PIPETTES[data['axis']] and data['volume'] is not None and data['volume'] > 0):
+            self.PIPETTES[data['axis']].volume = data['volume']
             
         self.save_pipette_values()
+
+        self.publish_calibrations()
         
         
     #from planner.js


### PR DESCRIPTION
This PR adds a simple and essential addition to the UI; setting the total volume of a pipette. This is the preferred way of calibrating a pipette, but has never been included in the 1.x UI.

This branch also made some fixes to `app/main.js`, found during testing:
1. Electron's `powerSaveBlocker.start()` returns an ID, not an object containing an `id` key
2. Cleaning up is moved to the `quit` event, because I found the `window-all-closed` event was not being called when quitting from the command line
