### PR TITLE
remove links to external websites

### DIFF
--- a/app/src/index.html
+++ b/app/src/index.html
@@ -37,11 +37,11 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="http://opentrons.com" target="_blank">
+          <a class="navbar-brand">
             <img src="images/logo.png" > </a>
           <ul class="nav navbar-nav navbar-left">
             <li>
-            <a href="https://github.com/opentrons" target="_blank" id="ot_app_version"></a>
+            <a id="ot_app_version"></a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
these open new electron windows, which is weird for users because then they realize our app is just a glorified browser, not to mention the fact that we don't want to link to external websites (though maybe we can have them launch the default browser? not sure if there's an non OS specific way to do that)
