### PR TITLE
changes walk dir for zip

### DIFF
--- a/scripts/zip_ot_app.py
+++ b/scripts/zip_ot_app.py
@@ -133,7 +133,7 @@ def zip_ot_app(build_tag, os_type):
             print(script_tab + "Error using zip command: {}".format(std_err))
     if os_type == "win":
         zip_output = zipfile.ZipFile(zip_app_path, 'w', zipfile.ZIP_DEFLATED)
-        for dirname, subdirs, subfiles in os.walk(current_app_path):
+        for dirname, subdirs, subfiles in os.walk('.'):
             zip_output.write(dirname)
             for filename in subfiles:
                 zip_output.write(os.path.join(dirname, filename))


### PR DESCRIPTION
The Windows zip files have contained the upper directories along with the OT app.

i.e.: if the app is in `/foo/bar/ot-app` the zip file contains `/foo/bar/ot-app`. But the zip file should only contain `ot-app` and not the empty directories above it.

To fix this you need to change the current working directory to the location where you have the file you will be zipping. Then call the zip command on that directory.
