### PR TITLE
20160912 095600 tcp fix take 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ node_modules
 dist
 
 .node-version
+.python-version
 app/backend-dist/mac/*
 !app/backend-dist/mac/.gitkeep
 app/backend-dist/win/*

--- a/app/main.js
+++ b/app/main.js
@@ -100,6 +100,7 @@ function execFile(filePath, extraArgs) {
  */
 function startBackend() {
     const userDataPath = app.getPath('userData');
+    console.log('User Data Path', userDataPath)
 
     if (process.platform == "darwin") {
       var backend_path = app.getAppPath() + "/backend-dist/mac/otone_client";

--- a/backend/backend/otone_client.py
+++ b/backend/backend/otone_client.py
@@ -50,7 +50,7 @@ if len(sys.argv) > 1:
 # Exit program if multiple processes are running
 if process_manager.check_is_running(perm_dir_path):
     print('Silently exiting due to previous running process')
-    exit(0)
+    sys.exit()
 
 disconnect_counter = 0
 disconnect_seconds_timeout = 30

--- a/backend/backend/otone_client.py
+++ b/backend/backend/otone_client.py
@@ -29,6 +29,8 @@ import time
 
 from autobahn.wamp.serializer import JsonSerializer, MsgPackSerializer
 
+import process_manager
+
 # If code is frozen (i.e. pyinstaller executable) then
 # file path is the sys._MEIPASS attribute
 if getattr(sys, 'frozen', None):
@@ -44,6 +46,11 @@ else:
 
 if len(sys.argv) > 1:
     perm_dir_path = sys.argv[1]
+
+# Exit program if multiple processes are running
+if process_manager.check_is_running(perm_dir_path):
+    print('Silently exiting due to previous running process')
+    exit(0)
 
 disconnect_counter = 0
 disconnect_seconds_timeout = 30

--- a/backend/backend/process_manager.py
+++ b/backend/backend/process_manager.py
@@ -27,12 +27,15 @@ def check_is_running(pid_dir):
         write_pid_file(pid_file_path)
         return False
 
-    last_pid = get_pid_from_file(pid_file_path)
+    last_pid = None
+    try:
+        last_pid = get_pid_from_file(pid_file_path)
+    except ValueError:
+        last_pid = None
+        os.remove(pid_file_path)
 
-    if last_pid == current_pid:
-        return True
 
-    if psutil.pid_exists(last_pid):
+    if last_pid and psutil.pid_exists(last_pid):
         return True
 
     write_pid_file(pid_file_path)

--- a/backend/backend/process_manager.py
+++ b/backend/backend/process_manager.py
@@ -1,0 +1,39 @@
+import json
+import os
+import psutil
+
+
+PID_FILENAME = 'otone_client.pid'
+
+
+def write_pid_file(pid_file_path):
+    current_pid = os.getpid()
+    with open(pid_file_path, 'w') as pid_file:
+        pid_file.write(json.dumps({'pid': current_pid}))
+
+
+def get_pid_from_file(pid_file_path):
+    with open(pid_file_path, 'r') as pid_file:
+        return int(json.load(pid_file).get('pid'))
+
+
+def check_is_running(pid_dir):
+    pid_file_path = os.path.join(pid_dir, PID_FILENAME)
+
+    current_pid = os.getpid()
+
+    # If the file doesn't exist, write the current process ID to the file
+    if not os.path.exists(pid_file_path):
+        write_pid_file(pid_file_path)
+        return False
+
+    last_pid = get_pid_from_file(pid_file_path)
+
+    if last_pid == current_pid:
+        return True
+
+    if psutil.pid_exists(last_pid):
+        return True
+
+    write_pid_file(pid_file_path)
+    return False


### PR DESCRIPTION
This PR prevents two backend process from running.
- The backend process will have to be invoked to use the same data dir path for this to work (which is consistently done when invoked by electron).
- You can test this locally by running `python backend/backend/otone_client.py /data/dir/path` twice (using the same path) and you'll find the second process exits.

I've not been able to replicate the issue of the TCP error occurring because two backend processes are running -- my app refuses to connect to the robot whatsoever.

@levthedev since you were able to replicate two backend process cause a TCP error can you verify this fixes that.
