### PR TITLE
20160815 023500 catch coordinate type error

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -12,6 +12,8 @@ const {app, powerSaveBlocker, BrowserWindow} = electron
 const addMenu = require('./menu').addMenu;
 const initAutoUpdater = require('./update_helpers').initAutoUpdater;
 
+const fs = require('fs')
+
 
 const winston = require('winston')
 
@@ -37,6 +39,10 @@ function createWindow () {
 }
 
 function startWampRouter() {
+
+    // winston seems to not create the file if it doesn't exist already
+    // to avoid this, .appendFileSync() will create the file incase it's not there
+    fs.appendFileSync(app.getPath('userData') + '/otone_data/router_logfile.txt', '');
 
     var wamp_logger = new (winston.Logger)({
         transports: [

--- a/backend/backend/smoothie_pyserial.py
+++ b/backend/backend/smoothie_pyserial.py
@@ -427,7 +427,12 @@ class Smoothie(object):
                             elif value > 0 and self.theState['direction'][n]>0:
                                 value = value + self.theState['direction'][n]
                                 self.theState['direction'][n] = 0
-                    cmd = cmd + str(float(value))
+
+                    try:
+                        cmd = cmd + str(float(value))
+                    except TypeError as e:
+                        logger.debug('Failed casting coordinate value {}'.format(value))
+                        cmd = cmd + str(float(0.0))
 
 
             self.try_add(cmd)

--- a/backend/backend/smoothie_pyserial.py
+++ b/backend/backend/smoothie_pyserial.py
@@ -617,7 +617,7 @@ class Smoothie(object):
                     s = serial.Serial(port)
                     s.close()
                     result.append(port)
-            except (OSError, serial.SerialException):
+            except (OSError, serial.SerialException, termios.error):
                 pass
         return result
 


### PR DESCRIPTION
This PR remedy three issues that came up during testing
1. The log file used by winston logger is not auto-created if it doesn't already exist. This is fixed with first calling `fs.appendFileSynce()` with no data, which will create the file.
2. Listing serial ports would throw an occasional error `termios.error`, most likely from trying to connect to previously-paired peripherals (like a mouse). This is fixed by swallowing this error, thus ignoring those devices
3. When hitting the `MoveTo` button for a non-calibrated container, the smoothie module was attempting to move to the coordinate `None`, which thew a `TypeError`. This error is now being caught, and the module default to coordinate `0.0` when this happens
