### PR TITLE
Add opt in for updates

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -160,11 +160,7 @@ app.on('ready', startWampRouter)
 app.on('ready', startBackend)
 app.on('ready', addMenu)
 app.on('ready', blockPowerSaver)
-
-if (getAutoUpdateToggle() == true) {
-  app.on('ready', initAutoUpdater)
-}
-
+app.on('ready', initAutoUpdater)
 app.on('ready', createContainersFolder)
 
 app.on('window-all-closed', function () {

--- a/app/main.js
+++ b/app/main.js
@@ -15,6 +15,7 @@ const winston = require('winston')
 
 const addMenu = require('./menu').addMenu;
 const initAutoUpdater = require('./update_helpers').initAutoUpdater;
+const getAutoUpdateToggle = require('./preferences').getAutoUpdateToggle;
 
 let backendProcess = undefined
 let powerSaverID = undefined
@@ -159,7 +160,11 @@ app.on('ready', startWampRouter)
 app.on('ready', startBackend)
 app.on('ready', addMenu)
 app.on('ready', blockPowerSaver)
-app.on('ready', initAutoUpdater)
+
+if (getAutoUpdateToggle() == true) {
+  app.on('ready', initAutoUpdater)
+}
+
 app.on('ready', createContainersFolder)
 
 app.on('window-all-closed', function () {

--- a/app/main.js
+++ b/app/main.js
@@ -15,7 +15,6 @@ const winston = require('winston')
 
 const addMenu = require('./menu').addMenu;
 const initAutoUpdater = require('./update_helpers').initAutoUpdater;
-const getAutoUpdateToggle = require('./preferences').getAutoUpdateToggle;
 
 let backendProcess = undefined
 let powerSaverID = undefined

--- a/app/menu.js
+++ b/app/menu.js
@@ -1,12 +1,11 @@
 module.exports.addMenu = addMenu;
 
-const fs = require('fs')
-const path = require('path')
-
 const electron = require("electron");
 const {app, dialog, Menu, MenuItem, shell} = electron;
 const zipFolder = require('zip-folder');
-
+const fs = require('fs')
+const path = require('path')
+const {getAutoUpdateToggle, toggleAutoUpdating} = require('./preferences')
 
 function addMenu() {
   const template =  [{
@@ -36,6 +35,11 @@ function addMenu() {
       {
         label: 'Open Containers Folder',
         click() { openContainersFolder() }
+      },
+      {
+        label: `Auto Update this App`,
+        type: "checkbox",
+        click() { toggleAutoUpdating() }
       }
     ]}
   ]
@@ -56,7 +60,6 @@ function downloadLogs() {
 }
 
 function openContainersFolder() {
-
   const containersFolderDir = app.getUserContainersPath();
 
   shell.showItemInFolder(containersFolderDir);

--- a/app/menu.js
+++ b/app/menu.js
@@ -39,6 +39,7 @@ function addMenu() {
       {
         label: `Auto Update this App`,
         type: "checkbox",
+        checked: getAutoUpdateToggle(),
         click() { toggleAutoUpdating() }
       }
     ]}

--- a/app/menu.js
+++ b/app/menu.js
@@ -3,8 +3,6 @@ module.exports.addMenu = addMenu;
 const electron = require("electron");
 const {app, dialog, Menu, MenuItem, shell} = electron;
 const zipFolder = require('zip-folder');
-const fs = require('fs')
-const path = require('path')
 const {getAutoUpdateToggle, toggleAutoUpdating} = require('./preferences')
 
 function addMenu() {

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ot-one-desktop-app",
   "productName": "OT One App",
-  "version": "1.1.8",
+  "version": "1.1.7",
   "description": "This is the frontend component the OpenTrons OT.One. It's a browser user interface served from the OT.One and it uses Autobahn|JS for connection to the backend running Crossbar.io.",
   "main": "main.js",
   "dependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -6,13 +6,15 @@
   "main": "main.js",
   "dependencies": {
     "autobahn": "^0.10.1",
+    "electron-json-storage": "^2.0.0",
+    "electron-settings": "^2.1.1",
     "electron-squirrel-startup": "^1.0.0",
     "fs": "0.0.2",
     "jquery": "^1.11.1",
     "nightlife-rabbit": "git+https://github.com/opentrons/nightlife-rabbit",
     "node-clogger": "git+https://github.com/christian-raedel/node-clogger.git#v0.3.3",
-    "zip-folder": "^1.0.0",
-    "winston": "^2.2.0"
+    "winston": "^2.2.0",
+    "zip-folder": "^1.0.0"
   },
   "repository": {
     "type": "git",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ot-one-desktop-app",
   "productName": "OT One App",
-  "version": "1.1.7",
+  "version": "1.1.6",
   "description": "This is the frontend component the OpenTrons OT.One. It's a browser user interface served from the OT.One and it uses Autobahn|JS for connection to the backend running Crossbar.io.",
   "main": "main.js",
   "dependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ot-one-desktop-app",
   "productName": "OT One App",
-  "version": "1.1.6",
+  "version": "1.1.8",
   "description": "This is the frontend component the OpenTrons OT.One. It's a browser user interface served from the OT.One and it uses Autobahn|JS for connection to the backend running Crossbar.io.",
   "main": "main.js",
   "dependencies": {

--- a/app/preferences.js
+++ b/app/preferences.js
@@ -1,0 +1,34 @@
+const storage = require('electron-json-storage');
+
+let autoUpdateToggle;
+
+function getAutoUpdateToggle() {
+  storage.get('preferences', function(error, data) {
+    if (data) {
+      autoUpdateToggle = !!data.autoUpdate
+    } else if (error) {
+      dialog.showMessageBox({
+        message: `Error toggling auto-update: \n\n${error}`,
+        buttons: ["OK"]
+      });
+    }
+  });
+  return autoUpdateToggle
+}
+
+function toggleAutoUpdating() {
+  storage.set('preferences', {autoUpdate: !!!getAutoUpdateToggle() }, function(error) {
+    if (error) {
+      dialog.showMessageBox({
+        message: `Error toggling auto-update: \n\n${error}`,
+        buttons: ["OK"]
+      });
+    }
+  });
+  console.log(getAutoUpdateToggle())
+}
+
+module.exports = {
+  getAutoUpdateToggle,
+  toggleAutoUpdating
+}

--- a/app/preferences.js
+++ b/app/preferences.js
@@ -6,6 +6,8 @@ settings.defaults({
   "autoUpdate": false
 });
 
+settings.applyDefaultsSync()
+
 function getAutoUpdateToggle() {
   return settings.getSync('autoUpdate')
 }

--- a/app/preferences.js
+++ b/app/preferences.js
@@ -1,31 +1,19 @@
-const storage = require('electron-json-storage');
+const electron = require('electron');
+const {dialog, Menu} = electron
+const settings = require('electron-settings')
 
-let autoUpdateToggle;
+settings.defaults({
+  "autoUpdate": false
+});
 
 function getAutoUpdateToggle() {
-  storage.get('preferences', function(error, data) {
-    if (data) {
-      autoUpdateToggle = !!data.autoUpdate
-    } else if (error) {
-      dialog.showMessageBox({
-        message: `Error toggling auto-update: \n\n${error}`,
-        buttons: ["OK"]
-      });
-    }
-  });
-  return autoUpdateToggle
+  return settings.getSync('autoUpdate')
 }
 
 function toggleAutoUpdating() {
-  storage.set('preferences', {autoUpdate: !!!getAutoUpdateToggle() }, function(error) {
-    if (error) {
-      dialog.showMessageBox({
-        message: `Error toggling auto-update: \n\n${error}`,
-        buttons: ["OK"]
-      });
-    }
-  });
-  console.log(getAutoUpdateToggle())
+  console.log(`before toggle: ${getAutoUpdateToggle()}`)
+  settings.setSync('autoUpdate', !getAutoUpdateToggle())
+  console.log(`after toggle: ${getAutoUpdateToggle()}`)
 }
 
 module.exports = {

--- a/app/preferences.js
+++ b/app/preferences.js
@@ -13,9 +13,7 @@ function getAutoUpdateToggle() {
 }
 
 function toggleAutoUpdating() {
-  console.log(`before toggle: ${getAutoUpdateToggle()}`)
   settings.setSync('autoUpdate', !getAutoUpdateToggle())
-  console.log(`after toggle: ${getAutoUpdateToggle()}`)
 }
 
 module.exports = {

--- a/app/preferences.js
+++ b/app/preferences.js
@@ -2,11 +2,18 @@ const electron = require('electron');
 const {dialog, Menu} = electron
 const settings = require('electron-settings')
 
-settings.defaults({
-  "autoUpdate": false
-});
+settings.on('create', pathToSettings => {
+  const result = dialog.showMessageBox({
+    message: `Do you want to turn on auto updating?`,
+    buttons: ["Yes", "No"]
+  });
 
-settings.applyDefaultsSync()
+  if (result == 0) {
+    settings.setSync('autoUpdate', true);
+  } else if (result == 1) {
+    settings.setSync('autoUpdate', false);
+  }
+})
 
 function getAutoUpdateToggle() {
   return settings.getSync('autoUpdate')

--- a/app/update_helpers.js
+++ b/app/update_helpers.js
@@ -1,6 +1,6 @@
 const electron = require("electron");
 const {app, dialog, autoUpdater} = electron;
-
+const {autoUpdateToggle, getAutoUpdateToggle} = require('./preferences')
 var UPDATE_SERVER_URL =  'http://ot-app-releases.herokuapp.com';
 
 
@@ -50,11 +50,9 @@ function initAutoUpdater () {
   var AUTO_UPDATE_URL = UPDATE_SERVER_URL + '?version=' + app.getVersion()
   console.log('Setting AUTO UPDATE URL to ' + AUTO_UPDATE_URL)
   autoUpdater.setFeedURL(AUTO_UPDATE_URL)
-  autoUpdater.checkForUpdates()
+  if (getAutoUpdateToggle()) autoUpdater.checkForUpdates()
 }
 
 module.exports = {
     initAutoUpdater
 };
-
-

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "iconUrl": "https://s3.amazonaws.com/ot-app-builds/win/icon.ico"
   },
   "dependencies": {
-    "electron-debug": "^1.0.1",
-    "electron-json-storage": "^2.0.0"
+    "electron-debug": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,20 +2,15 @@
   "scripts": {
     "postinstall": "install-app-deps",
     "clean": "rm -rf ./out && rm -rf ./releases/*",
-
     "build:backend": "python3.4 scripts/build_pyinstaller.py",
     "build:frontend": "python scripts/build_electron_app_with_builder.py",
     "release": "npm run build:backend && npm run build:frontend",
-
     "build:backend:mac": "python3.4 scripts/build_pyinstaller.py",
     "build:backend:win": "C:\\Python34\\python scripts\\build_pyinstaller.py",
-
     "build:frontend:mac": "python3.4 scripts/build_electron_app_with_builder.py",
     "build:frontend:win": "C:\\Python34\\python scripts\\build_electron_app_with_builder.py",
-
     "release:mac": "npm run build:backend:mac && npm run build:frontend:mac",
     "release:win": "npm run build:backend:win && npm run build:frontend:win",
-
     "start": "NODE_ENV=development electron app/"
   },
   "devDependencies": {
@@ -50,13 +45,17 @@
       ]
     },
     "mac": {
-      "target": ["dmg", "zip"]
+      "target": [
+        "dmg",
+        "zip"
+      ]
     }
   },
   "win": {
     "iconUrl": "https://s3.amazonaws.com/ot-app-builds/win/icon.ico"
   },
   "dependencies": {
-    "electron-debug": "^1.0.1"
+    "electron-debug": "^1.0.1",
+    "electron-json-storage": "^2.0.0"
   }
 }


### PR DESCRIPTION
This PR adds a menu item under File that lets you toggle on or off the auto updating that was previously always enabled. To test it, clone this branch, set your version number to be something lower than the current version, and open the app. It should not auto update. If you check the new toggle button, then whenever you open the app it should update. This persists across sessions of the app.

Also, from now on, all preferences should be stored the same way this is being stored (through sync get/set methods on electron-settings; async caused issues for me). I'm not currently exporting the settings file to be saved when the logs are downloaded, but I can add that in when we have more settings (or tomorrow morning to save us the trouble).
