### PR TITLE
add toggle for crash reporter

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -6,7 +6,7 @@ const http       = require('http')
 const path = require('path')
 
 const electron = require('electron')
-const {app, BrowserWindow, powerSaveBlocker} = electron
+const {app, BrowserWindow, powerSaveBlocker, crashReporter} = electron
 
 const autobahn = require('autobahn')
 const $ = jQuery = require('jquery')
@@ -15,6 +15,7 @@ const winston = require('winston')
 
 const addMenu = require('./menu').addMenu;
 const initAutoUpdater = require('./update_helpers').initAutoUpdater;
+const {toggleSetting, getSetting} = require('./preferences')
 
 let backendProcess = undefined
 let powerSaverID = undefined
@@ -142,6 +143,20 @@ function createContainersFolder() {
   }
 }
 
+function startCrashReporter() {
+  if (getSetting("crashReport")) {
+    console.log("Crash Reporter Enabled")
+    crashReporter.start({
+      productName: 'OpenTrons App',
+      companyName: 'OpenTrons',
+      submitURL: 'http://54.213.42.102:1127/post',
+      autoSubmit: true
+    });
+  } else {
+    console.log("Crash Reporter Disabled")
+  }
+}
+
 app.getUserContainersPath = function(){
   return path.join(app.getPath('userData'), 'containers');
 }
@@ -161,6 +176,7 @@ app.on('ready', addMenu)
 app.on('ready', blockPowerSaver)
 app.on('ready', initAutoUpdater)
 app.on('ready', createContainersFolder)
+app.on('ready', startCrashReporter)
 
 app.on('window-all-closed', function () {
     app.quit()

--- a/app/menu.js
+++ b/app/menu.js
@@ -3,7 +3,7 @@ module.exports.addMenu = addMenu;
 const electron = require("electron");
 const {app, dialog, Menu, MenuItem, shell} = electron;
 const zipFolder = require('zip-folder');
-const {getAutoUpdateToggle, toggleAutoUpdating} = require('./preferences')
+const {getSetting, toggleSetting} = require('./preferences')
 
 function addMenu() {
   const template =  [{
@@ -37,8 +37,14 @@ function addMenu() {
       {
         label: `Auto Update this App`,
         type: "checkbox",
-        checked: getAutoUpdateToggle(),
-        click() { toggleAutoUpdating() }
+        checked: getSetting("autoUpdate"),
+        click() { toggleSetting("autoUpdate") }
+      },
+      {
+        label: `Anonymously Report Crashes`,
+        type: "checkbox",
+        checked: getSetting("crashReport"),
+        click() { toggleSetting("crashReport") }
       }
     ]}
   ]

--- a/app/preferences.js
+++ b/app/preferences.js
@@ -15,15 +15,15 @@ settings.on('create', pathToSettings => {
   }
 })
 
-function getAutoUpdateToggle() {
-  return settings.getSync('autoUpdate')
+function getSetting(setting) {
+  return settings.getSync(setting)
 }
 
-function toggleAutoUpdating() {
-  settings.setSync('autoUpdate', !getAutoUpdateToggle())
+function toggleSetting(setting) {
+  settings.setSync(setting, !getSetting(setting))
 }
 
 module.exports = {
-  getAutoUpdateToggle,
-  toggleAutoUpdating
+  getSetting,
+  toggleSetting
 }

--- a/app/update_helpers.js
+++ b/app/update_helpers.js
@@ -1,6 +1,6 @@
 const electron = require("electron");
 const {app, dialog, autoUpdater} = electron;
-const {autoUpdateToggle, getAutoUpdateToggle} = require('./preferences')
+const {toggleSetting, getSetting} = require('./preferences')
 var UPDATE_SERVER_URL =  'http://ot-app-releases.herokuapp.com';
 
 
@@ -48,7 +48,7 @@ function initAutoUpdater () {
   )
 
   var AUTO_UPDATE_URL = UPDATE_SERVER_URL + '?version=' + app.getVersion()
-   
+
   //  If platform is Windows, use S3 file server instead of update server.
   //  please see /docs/windows_updating.txt for more information
   if (process.platform === 'win32') {
@@ -56,7 +56,7 @@ function initAutoUpdater () {
   }
   console.log('Setting AUTO UPDATE URL to ' + AUTO_UPDATE_URL)
   autoUpdater.setFeedURL(AUTO_UPDATE_URL)
-  if (getAutoUpdateToggle()) autoUpdater.checkForUpdates()
+  if (getSetting("autoUpdate")) autoUpdater.checkForUpdates()
 }
 
 module.exports = {


### PR DESCRIPTION
This PR adds a toggle for turning on or off the Crash Reporter module on startup. I also refactored the preferences module so that instead of having dedicated `get` and `toggle` functions for each settings, there is only one of each of those functions that take an argument for which setting to get or toggle.

I also forked and created a server that the Crash Reporter will send it's reports to. Right now that server is located at http://54.213.42.102:1127, though if we use it enough we can get some nicer domain name for it. It's just an AWS EC2 instance that I set a daemon on to run this forked mini-breakpad-server (`nohup node lib/app.js &` for future reference). The only useful info it records as of now is the app version, date/time, platform/CPU, and Electron version. In the future, we could convert the thread dumps it provides into full stack traces, but that is out of the scope of this PR.

Here is the repo for the mini-breakpad-server - https://github.com/OpenTrons/mini-breakpad-server
