### PR TITLE
20160902 014800 after halt wait for emergency response

### DIFF
--- a/backend/backend/smoothie_pyserial.py
+++ b/backend/backend/smoothie_pyserial.py
@@ -274,7 +274,6 @@ class Smoothie(object):
             self.already_trying = False
         if 'Emergency Stop Requested' in msg:
             self.needs_M999 = True
-            self.sent_M112 = False
         if msg.find('{')>=0 and not self.sent_M112:
             msg = msg[msg.index('{'):]
 
@@ -575,6 +574,7 @@ class Smoothie(object):
             time.sleep(0.1)
 
         self.needs_M999 = False
+        self.sent_M112 = False
         
         self.send(self._dict['on'] + '\r\n')
         time.sleep(0.5)


### PR DESCRIPTION
This PR addresses multiple customers reporting their long protocols were stopping at seemingly random places in the protocol. Looking into their log files, we found the motor driver and smoothieboard's serial handshake was losing state when `M112` commands were sent.

To prevent this, this PR has the motor driver send `M112`, then wait for the Smoothieboard to specifically respond "Emergency Stop Requested". Only then will the motor driver return back to sending a home command. This is a quick fix, as opposed to just rewriting/replacing the motor driver in 1.x
