### PR TITLE
20160908 105900 only read json container files

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -182,7 +182,8 @@ app.getUserJSONFiles = function(){
   var filenames = fs.readdirSync(app.getUserContainersPath());
 
   filenames = filenames.filter(function(fileName) {
-    return fileName.indexOf('.json') > 0;
+    var temp = fileName.split('.');
+    return temp[temp.length-1] == 'json';
   });
 
   return filenames.map(function(fileName){

--- a/app/main.js
+++ b/app/main.js
@@ -181,7 +181,7 @@ app.getUserContainersPath = function(){
 app.getUserJSONFiles = function(){
   var filenames = fs.readdirSync(app.getUserContainersPath());
 
-  filenames.filter(function(fileName) {
+  filenames = filenames.filter(function(fileName) {
     return fileName.indexOf('.json') > 0;
   });
 

--- a/app/main.js
+++ b/app/main.js
@@ -181,6 +181,10 @@ app.getUserContainersPath = function(){
 app.getUserJSONFiles = function(){
   var filenames = fs.readdirSync(app.getUserContainersPath());
 
+  filenames.filter(function(fileName) {
+    return fileName.indexOf('.json') > 0;
+  });
+
   return filenames.map(function(fileName){
     return path.join(app.getUserContainersPath(), fileName);
   });

--- a/app/src/js/loadFiles.js
+++ b/app/src/js/loadFiles.js
@@ -299,8 +299,6 @@ function loadFile(e) {
 
       if(tempProtocol) {
 
-        TIPRACKS = {'a':[],'b':[]}; // clear tipracks
-
         //if we find the info generate html elements
         if(tempProtocol.deck && tempProtocol.head && tempProtocol.instructions && tempProtocol.ingredients) {
 
@@ -316,6 +314,8 @@ function loadFile(e) {
           }
 
           CURRENT_PROTOCOL = tempProtocol;
+
+          TIPRACKS = {'a':[],'b':[]}; // clear tipracks
 
           document.getElementById('runButton').disabled = false;
           document.getElementById('runButton').classList.add('tron-blue');

--- a/app/src/js/loadFiles.js
+++ b/app/src/js/loadFiles.js
@@ -301,14 +301,27 @@ function loadFile(e) {
 
         TIPRACKS = {'a':[],'b':[]}; // clear tipracks
 
-        setPipetteNames(tempProtocol); // set the names of the pipettes in the container table
         //if we find the info generate html elements
         if(tempProtocol.deck && tempProtocol.head && tempProtocol.instructions && tempProtocol.ingredients) {
+
+          // test to see if there's any compile errors
+          // but don't actually run the compiled output returned from "createRobotProtocol"
+          try {
+            createRobotProtocol(tempProtocol);
+          }
+          catch (error) {
+            console.log(error);
+            alert(error);
+            return;
+          }
+
+          CURRENT_PROTOCOL = tempProtocol;
 
           document.getElementById('runButton').disabled = false;
           document.getElementById('runButton').classList.add('tron-blue');
 
-          CURRENT_PROTOCOL = tempProtocol;
+          setPipetteNames(CURRENT_PROTOCOL); // set the names of the pipettes in the container table
+
           for (var k in tempProtocol.head){
             console.log('the k: ',k);
             console.log('the head:')


### PR DESCRIPTION
This PR address two issues in the frontend:
1. Custom container files are only read in if they end with a `.json` extension
2. Newly loaded protocols are immediately compiled to see if they pass, so errors show up immediately (not only after you press `Run Job`)
